### PR TITLE
Surface runtime errors not caught by matchers

### DIFF
--- a/dist/chain.js
+++ b/dist/chain.js
@@ -27,6 +27,8 @@ const chainMatchers = (matchers, originalMatchers = matchers) => {
 
           return chainMatchers(originalMatchers); // chain the original matchers again
         } catch (error) {
+          // in case the error is a runtime error, not a failing matcher
+          if (!error.matcherResult) throw error;
           throw new JestAssertionError(error.matcherResult.message, newMatcher);
         }
       };

--- a/src/chain.js
+++ b/src/chain.js
@@ -19,7 +19,7 @@ const chainMatchers = (matchers, originalMatchers = matchers) => {
           return chainMatchers(originalMatchers); // chain the original matchers again
         } catch (error) {
           // in case the error is a runtime error, not a failing matcher
-          if (!error.matcherResult) throw error
+          if (!error.matcherResult) throw error;
           throw new JestAssertionError(error.matcherResult.message, newMatcher);
         }
       };

--- a/src/chain.js
+++ b/src/chain.js
@@ -18,6 +18,8 @@ const chainMatchers = (matchers, originalMatchers = matchers) => {
           matcher(...args); // run matcher
           return chainMatchers(originalMatchers); // chain the original matchers again
         } catch (error) {
+          // in case the error is a runtime error, not a failing matcher
+          if (!error.matcherResult) throw error
           throw new JestAssertionError(error.matcherResult.message, newMatcher);
         }
       };

--- a/src/chain.test.js
+++ b/src/chain.test.js
@@ -200,4 +200,16 @@ describe('.chain', () => {
 
     expect(() => chain(expectMock)('hello').toBe('hi')).toThrowErrorMatchingInlineSnapshot('"blah"');
   });
+
+  it('throws original error when it does not fail the matcher', () => {
+    expect.assertions(1);
+    const expectMock = jest.fn(() => ({
+      toBe: () => {
+        const error = new Error('original error');
+        throw error;
+      }
+    }));
+
+    expect(() => chain(expectMock)('hello').toBe('hi')).toThrowErrorMatchingInlineSnapshot('"original error"');
+  });
 });


### PR DESCRIPTION
Without this change, a test which throws a runtime error that doesn't fail a matcher will always result in this message:
```
Cannot read property 'message' of undefined
TypeError: Cannot read property 'message' of undefined
```
The actual error is hidden.